### PR TITLE
fix: fatal error on plugin activation

### DIFF
--- a/src/plugin/includes/class-podlove-web-player-shortcode.php
+++ b/src/plugin/includes/class-podlove-web-player-shortcode.php
@@ -59,7 +59,9 @@ class Podlove_Web_Player_Shortcode {
 
     $this->options = new Podlove_Web_Player_Options( $this->plugin_name );
     $api = new Podlove_Web_Player_Embed_API( $this->plugin_name );
-    $this->routes = $api->routes();
+    add_action('rest_api_init', function() use ($api) {
+      $this->routes = $api->routes();
+    });
   }
 
   /**


### PR DESCRIPTION
The `routes` method must be called after the `rest_api_init` action, otherwise it fails.

Otherwise the following error occurs:

> **Fatal error:** Uncaught Error: Call to a member function using_index_permalinks() on null in /wp/wp-includes/rest-api.php:354 Stack trace: 
#0 /wp/wp-includes/rest-api.php(414): get_rest_url(NULL, '/podlove-web-pl...', 'rest') 
#1 /wp/wp-content/plugins/podlove-web-player-wp-plugin/dist/includes/class-podlove-web-player-embed-api.php(51): rest_url('podlove-web-pla...') 
#2 /wp/wp-content/plugins/podlove-web-player-wp-plugin/dist/includes/class-podlove-web-player-shortcode.php(64): Podlove_Web_Player_Embed_API->routes() 
#3 /wp/wp-content/plugins/podlove-web-player-wp-plugin/dist/public/class-podlove-web-player-public.php(82): Podlove_Web_Player_Shortcode->__construct('podlove-web-pla...', '1.0.0') 
#4 /wp/wp-content/plugins/podlove-web-player-wp-plugin/dist/includes/class-podlove-web-player.php(198): Podlove_Web_Player_Public->__construct('podlove-web- in /wp/wp-includes/rest-api.php on line 354

alternatively, init the shortcode class on the `rest_api_init` action.