### PR TITLE
PHP Warning

### DIFF
--- a/src/plugin/includes/class-podlove-web-player-embed-data.php
+++ b/src/plugin/includes/class-podlove-web-player-embed-data.php
@@ -121,6 +121,9 @@ class Podlove_Web_Player_Embed_Data
 
         // Disable subscribe when no clients are available
         $availableClients = $config['subscribe-button']['clients'];
+        if (!is_array($availableClients)) {
+          $availableClients = [];
+        }
         $config['subscribe-button'] = count($availableClients) > 0 ? $config['subscribe-button'] : null;
 
         switch ($relatedEpisodes['source']) {

--- a/src/plugin/includes/class-podlove-web-player-options.php
+++ b/src/plugin/includes/class-podlove-web-player-options.php
@@ -278,6 +278,10 @@ class Podlove_Web_Player_Options
             $options = json_decode(get_option($this->plugin_name), true);
         }
 
+        if (!is_array($options['settings'])) {
+          $options['settings'] = [];
+        }
+
         return array_replace_recursive($options, array(
             'configs' => $this->defaults('config', $options['configs'] ?? [], $this->defaultConfig),
             'themes' => $this->defaults('theme', $options['themes'] ?? [], $this->defaultTheme),


### PR DESCRIPTION
v5.4.5 don't fixed them

PHP Warning: array_replace_recursive(): Argument #1 is not an array in /wp-content/plugins/podlove-web-player/includes/class-podlove-web-player-options.php on line 285

PHP Warning: count(): Parameter must be an array or an object that implements Countable in /wp-content/plugins/podlove-web-player/includes/class-podlove-web-player-embed-data.php on line 124