### PR TITLE
Remove trailing slash from REST route namespace

### DIFF
--- a/src/plugin/includes/class-podlove-web-player-embed-api.php
+++ b/src/plugin/includes/class-podlove-web-player-embed-api.php
@@ -175,7 +175,7 @@ class Podlove_Web_Player_Embed_API
             )
         );
 
-        register_rest_route($this->plugin_name . '/', 'options',
+        register_rest_route($this->plugin_name, 'options',
             array(
                 'methods' => 'GET',
                 'callback' => array($this, 'options'),


### PR DESCRIPTION
The namespace of a REST route should not contain a leading or trailing slash. WordPress emits a warning in this case:

"Namespace must not start or end with a slash."

see `/wp-includes/rest-api.php`, function `register_rest_route()`

Observed response header (with German locale activated):

`x-wp-doingitwrong: register_rest_route (ab 5.4.2; Der Namensraum darf nicht mit einem Schrägstrich beginnen oder enden.)`